### PR TITLE
Remove outdated modules from cubical.cabal

### DIFF
--- a/cubical.cabal
+++ b/cubical.cabal
@@ -24,4 +24,4 @@ executable cubical
   build-tools:         alex, happy
   default-language:    Haskell2010
   hs-source-dirs:      .
-  other-modules:       CTT, Concrete, Eval, MTT, MTTtoCTT, Pretty
+  other-modules:       CTT, Concrete, Eval, Pretty


### PR DESCRIPTION
These modules seem to date to before the cubical evaluator was internalized; this change allows you to run `cabal install` again.
